### PR TITLE
Failed to load resource .../html/console.html because *nix is case-sensitive

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ define(function (require, exports, module) {
     
     var AppInit       = brackets.getModule("utils/AppInit"),
         Resizer       = brackets.getModule("utils/Resizer"),
-        ConsoleHTML   = require("text!html/Console.html");
+        ConsoleHTML   = require("text!html/console.html");
     
     var _init = false;
     var $console,


### PR DESCRIPTION
Using the extension on Linux results in no console and the following errors in Developer Tools:

```
Failed to load resource file:///home/miki/.config/Brackets/extensions/user/brackets-console/html/Console.html
Uncaught TypeError: Cannot read property 'scrollHeight' of undefined main.js:27
```

This is because Linux filenames are case sensitive.
